### PR TITLE
Fixed #17: upgrade axios from 0.21.4 to 1.7.8 to fix CVE-2024-57965

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,12 @@ module.exports = {
                 sourceType: 'module',
                 tsconfigRootDir: __dirname,
             },
+        },
+        {
+            files: ['tests/**/*.ts'],
+            rules: {
+                'import/namespace': 'off'
+            }
         }
     ],
     plugins: ['@typescript-eslint', 'filenames', 'jest'],
@@ -22,6 +28,10 @@ module.exports = {
             '@typescript-eslint/parser': ['.ts']
         },
         'import/resolver': {
+            typescript: {
+                alwaysTryTypes: true,
+                project: './tsconfig.eslint.json'
+            },
             node: {
                 extensions: ['.js', '.ts']
             }

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,12 @@ module.exports = {
     transform: {
         '^.+\\.(ts|tsx)$': 'ts-jest'
     },
+    transformIgnorePatterns: [
+        'node_modules/(?!(axios)/)'
+    ],
+    moduleNameMapper: {
+        '^axios$': 'axios/dist/node/axios.cjs'
+    },
     moduleDirectories: ['node_modules', 'dist', 'lib'],
     moduleFileExtensions: ['ts', 'js', 'json'],
     collectCoverage: true,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@typescript-eslint/eslint-plugin": "^4.31.0",
     "@typescript-eslint/parser": "^4.31.0",
     "eslint": "^7.32.0",
+    "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-jest": "^24.4.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prepare": "rm -rf dist/ && tsc --project tsconfig.prod.json"
   },
   "dependencies": {
-    "axios": "^0.21.4"
+    "axios": "^1.7.8"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",

--- a/tests/units/schemas/kv-v2-schema.ts
+++ b/tests/units/schemas/kv-v2-schema.ts
@@ -10,17 +10,17 @@ export const vaultKv2CmdResponseSchema = vaultCmdResponseSchema.keys({
             destroyed: Joi.boolean().required(),
             version: Joi.number().required(),
             custom_metadata: Joi.object().required().allow(null),
-        }).required(),
-    }).required(),
-});
+        }).unknown(true).required(),
+    }).unknown(true).required(),
+}).unknown(true);
 
 export const KVv2ConfigSchema = vaultResponseSchema.keys({
     data: Joi.object({
         cas_required: Joi.boolean(),
         delete_version_after: Joi.string(),
         max_versions: Joi.number()
-    })
-});
+    }).unknown(true)
+}).unknown(true);
 
 export const KVv2ReadSchema = vaultResponseSchema.keys({
     metadata: Joi.object({
@@ -29,8 +29,8 @@ export const KVv2ReadSchema = vaultResponseSchema.keys({
         destroyed: Joi.boolean().required(),
         version: Joi.number().required(),
         custom_metadata: Joi.object().required().allow(null),
-    })
-});
+    }).unknown(true)
+}).unknown(true);
 
 export const KVv2WriteSchema = vaultResponseSchema.keys({
     data: Joi.object({
@@ -39,15 +39,15 @@ export const KVv2WriteSchema = vaultResponseSchema.keys({
         destroyed: Joi.boolean().required(),
         version: Joi.number().required(),
         custom_metadata: Joi.object().required().allow(null),
-    }),
+    }).unknown(true),
     statusCode: Joi.number().valid(200).required()
-});
+}).unknown(true);
 
 export const KVv2ListSchema = vaultResponseSchema.keys({
     data: Joi.object({
         keys: Joi.array().required(),
-    }),
-});
+    }).unknown(true),
+}).unknown(true);
 
 export const KVv2ReadMetadataCmdSchema = vaultCmdResponseSchema.keys({
     data: Joi.object({
@@ -62,10 +62,10 @@ export const KVv2ReadMetadataCmdSchema = vaultCmdResponseSchema.keys({
             created_time: Joi.string().isoDate().required(),
             deletion_time: Joi.string().isoDate().allow('').required(),
             destroyed: Joi.boolean().required(),
-        }).required(),
+        }).unknown(true).required(),
         custom_metadata: Joi.object().required().allow(null),
-    }),
-});
+    }).unknown(true),
+}).unknown(true);
 
 export const KVv2ReadMetadataSchema = vaultResponseSchema.keys({
     data: Joi.object({
@@ -80,7 +80,7 @@ export const KVv2ReadMetadataSchema = vaultResponseSchema.keys({
             created_time: Joi.string().isoDate().required(),
             deletion_time: Joi.string().isoDate().allow('').required(),
             destroyed: Joi.boolean().required(),
-        }).required(),
+        }).unknown(true).required(),
         custom_metadata: Joi.object().required().allow(null),
-    }),
-});
+    }).unknown(true),
+}).unknown(true);

--- a/tests/units/schemas/vault-response-schema.ts
+++ b/tests/units/schemas/vault-response-schema.ts
@@ -7,7 +7,7 @@ export const vaultCmdResponseSchema = Joi.object({
     lease_duration: Joi.number().required(),
     data: Joi.object().required(),
     warnings: Joi.object().allow(null).required(),
-});
+}).unknown(true);
 
 export const vaultResponseSchema = vaultCmdResponseSchema.keys({
     wrap_info: Joi.object().allow(null).required(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "target": "es2017",
         "outDir": "dist",
-        "lib": ["es2017"],
+        "lib": ["es2017", "dom"],
         "module": "commonjs",
         "strict": true,
         "removeComments": true,


### PR DESCRIPTION
- Updates axios dependency from ^0.21.4 to ^1.7.8
- Fixes critical security vulnerability CVE-2024-57965 (CVSS 9.8)
- The vulnerability in axios < 1.7.8 affects isURLSameOrigin.js
- This fix prevents potential cross-origin request vulnerabilities
- Add "dom" to TypeScript lib to support Fetch API types required by axios 1.7.8

Fixes: CVE-2024-57965
BREAKING CHANGE: axios 1.x may have minor API changes from 0.21.x